### PR TITLE
update goshuirc/ircmsg to latest master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -31,11 +31,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9ab15495704fb3cd7f857071a09379c5829e15ce0a9d641af089d646a0f9b663"
+  digest = "1:7d3bc2bb6bc3f4329e86776c00741cb6ad663f0b29cf7621fdaa95e8c8bac8d6"
   name = "github.com/goshuirc/irc-go"
   packages = ["ircmsg"]
   pruneopts = "NUT"
-  revision = "8d136c4f92871c1c132bf702022363add479291b"
+  revision = "ca74bf6a176d2d1dce6f28f99901a2d48d8da2bd"
 
 [[projects]]
   branch = "master"

--- a/encode_test.go
+++ b/encode_test.go
@@ -73,11 +73,11 @@ func runEncoderBenchmarks(b *testing.B, raw string) {
 	})
 
 	b.Run("goshuirc/irc-go/ircmsg", func(b *testing.B) {
-		m, _ := ircmsg.ParseLine(raw)
+		m, _ := ircmsg.ParseLineStrict(raw, false, 0)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			m.LineBytes() //nolint:errcheck
+			m.LineBytesStrict(false, 0) //nolint:errcheck
 		}
 	})
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -60,7 +60,7 @@ func runParserBenchmarks(b *testing.B, raw string) {
 
 	b.Run("goshuirc/irc-go/ircmsg", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ircmsg.ParseLine(raw)
+			ircmsg.ParseLineStrict(raw, false, 0)
 		}
 	})
 

--- a/vendor/github.com/goshuirc/irc-go/ircmsg/message.go
+++ b/vendor/github.com/goshuirc/irc-go/ircmsg/message.go
@@ -1,4 +1,6 @@
-// written by Daniel Oaks <daniel@danieloaks.net>
+// Copyright (c) 2016-2019 Daniel Oaks <daniel@danieloaks.net>
+// Copyright (c) 2018-2019 Shivaram Lingamneni <slingamn@cs.stanford.edu>
+
 // released under the ISC license
 
 package ircmsg
@@ -9,239 +11,370 @@ import (
 	"strings"
 )
 
+const (
+	// "The size limit for message tags is 8191 bytes, including the leading
+	//  '@' (0x40) and trailing space ' ' (0x20) characters."
+	MaxlenTags = 8191
+
+	// MaxlenTags - ('@' + ' ')
+	MaxlenTagData = MaxlenTags - 2
+
+	// "Clients MUST NOT send messages with tag data exceeding 4094 bytes,
+	//  this includes tags with or without the client-only prefix."
+	MaxlenClientTagData = 4094
+
+	// "Servers MUST NOT add tag data exceeding 4094 bytes to messages."
+	MaxlenServerTagData = 4094
+
+	// '@' + MaxlenClientTagData + ' '
+	// this is the analogue of MaxlenTags when the source of the message is a client
+	MaxlenTagsFromClient = MaxlenClientTagData + 2
+)
+
 var (
 	// ErrorLineIsEmpty indicates that the given IRC line was empty.
 	ErrorLineIsEmpty = errors.New("Line is empty")
-	// ErrorTagsContainsBadChar indicates that the passed tag string contains a space or newline.
-	ErrorTagsContainsBadChar = errors.New("Tag string contains bad character (such as a space or newline)")
+	// ErrorLineContainsBadChar indicates that the line contained invalid characters
+	ErrorLineContainsBadChar = errors.New("Line contains invalid characters")
+	// ErrorLineTooLong indicates that the message exceeded the maximum tag length
+	// (the name references 417 ERR_INPUTTOOLONG; we reserve the right to return it
+	// for messages that exceed the non-tag length limit)
+	ErrorLineTooLong = errors.New("Line could not be parsed because a specified length limit was exceeded")
+
+	ErrorCommandMissing = errors.New("IRC messages MUST have a command")
+	ErrorBadParam       = errors.New("Cannot have an empty param, a param with spaces, or a param that starts with ':' before the last parameter")
 )
 
 // IrcMessage represents an IRC message, as defined by the RFCs and as
 // extended by the IRCv3 Message Tags specification with the introduction
 // of message tags.
 type IrcMessage struct {
-	Tags    map[string]TagValue
-	Prefix  string
-	Command string
-	Params  []string
-	// SourceLine represents the original line that constructed this message, when created from ParseLine.
-	SourceLine string
+	Prefix         string
+	Command        string
+	Params         []string
+	tags           map[string]string
+	clientOnlyTags map[string]string
 }
 
-// ParseLine creates and returns an IrcMessage from the given IRC line.
-//
-// Quirks:
-//
-//   The RFCs say that last parameters with no characters MUST be a trailing.
-//   IE, they need to be prefixed with ":". We disagree with that and handle
-//   incoming last empty parameters whether they are trailing or ordinary
-//   parameters. However, we do follow that rule when emitting lines.
-func ParseLine(line string) (IrcMessage, error) {
-	return parseLine(line, 0, 0, false)
+// GetTag returns whether a tag is present, and if so, what its value is.
+func (msg *IrcMessage) GetTag(tagName string) (present bool, value string) {
+	if len(tagName) == 0 {
+		return
+	} else if tagName[0] == '+' {
+		value, present = msg.clientOnlyTags[tagName]
+		return
+	} else {
+		value, present = msg.tags[tagName]
+		return
+	}
 }
 
-// ParseLineMaxLen creates and returns an IrcMessage from the given IRC line,
+// HasTag returns whether a tag is present.
+func (msg *IrcMessage) HasTag(tagName string) (present bool) {
+	present, _ = msg.GetTag(tagName)
+	return
+}
+
+// SetTag sets a tag.
+func (msg *IrcMessage) SetTag(tagName, tagValue string) {
+	if len(tagName) == 0 {
+		return
+	} else if tagName[0] == '+' {
+		if msg.clientOnlyTags == nil {
+			msg.clientOnlyTags = make(map[string]string)
+		}
+		msg.clientOnlyTags[tagName] = tagValue
+	} else {
+		if msg.tags == nil {
+			msg.tags = make(map[string]string)
+		}
+		msg.tags[tagName] = tagValue
+	}
+}
+
+// DeleteTag deletes a tag.
+func (msg *IrcMessage) DeleteTag(tagName string) {
+	if len(tagName) == 0 {
+		return
+	} else if tagName[0] == '+' {
+		delete(msg.clientOnlyTags, tagName)
+	} else {
+		delete(msg.tags, tagName)
+	}
+}
+
+// UpdateTags is a convenience to set multiple tags at once.
+func (msg *IrcMessage) UpdateTags(tags map[string]string) {
+	for name, value := range tags {
+		msg.SetTag(name, value)
+	}
+}
+
+// AllTags returns all tags as a single map.
+func (msg *IrcMessage) AllTags() (result map[string]string) {
+	result = make(map[string]string, len(msg.tags)+len(msg.clientOnlyTags))
+	for name, value := range msg.tags {
+		result[name] = value
+	}
+	for name, value := range msg.clientOnlyTags {
+		result[name] = value
+	}
+	return
+}
+
+// ClientOnlyTags returns the client-only tags (the tags with the + prefix).
+// The returned map may be internal storage of the IrcMessage object and
+// should not be modified.
+func (msg *IrcMessage) ClientOnlyTags() map[string]string {
+	return msg.clientOnlyTags
+}
+
+// ParseLine creates and returns a message from the given IRC line.
+func ParseLine(line string) (ircmsg IrcMessage, err error) {
+	return parseLine(line, 0, 0)
+}
+
+// ParseLineStrict creates and returns an IrcMessage from the given IRC line,
 // taking the maximum length into account and truncating the message as appropriate.
-//
-// Quirks:
-//
-//   The RFCs say that last parameters with no characters MUST be a trailing.
-//   IE, they need to be prefixed with ":". We disagree with that and handle
-//   incoming last empty parameters whether they are trailing or ordinary
-//   parameters. However, we do follow that rule when emitting lines.
-func ParseLineMaxLen(line string, maxlenTags, maxlenRest int) (IrcMessage, error) {
-	return parseLine(line, maxlenTags, maxlenRest, true)
+// If fromClient is true, it enforces the client limit on tag data length (4094 bytes),
+// allowing the server to return ERR_INPUTTOOLONG as appropriate. If truncateLen is
+// nonzero, it is the length at which the non-tag portion of the message is truncated.
+func ParseLineStrict(line string, fromClient bool, truncateLen int) (ircmsg IrcMessage, err error) {
+	maxTagDataLength := MaxlenTagData
+	if fromClient {
+		maxTagDataLength = MaxlenClientTagData
+	}
+	return parseLine(line, maxTagDataLength, truncateLen)
 }
 
-// parseLine does the actual line parsing for the above user-facing functions.
-func parseLine(line string, maxlenTags, maxlenRest int, useMaxLen bool) (IrcMessage, error) {
-	line = strings.Trim(line, "\r\n")
-	var ircmsg IrcMessage
+// slice off any amount of '\r' or '\n' from the end of the string
+func trimFinalNewlines(str string) string {
+	var i int
+	for i = len(str) - 1; 0 <= i && (str[i] == '\r' || str[i] == '\n'); i -= 1 {
+	}
+	return str[:i+1]
+}
 
-	ircmsg.SourceLine = line
+func parseLine(line string, maxTagDataLength int, truncateLen int) (ircmsg IrcMessage, err error) {
+	if strings.IndexByte(line, '\x00') != -1 {
+		err = ErrorLineContainsBadChar
+		return
+	}
+
+	line = trimFinalNewlines(line)
 
 	if len(line) < 1 {
 		return ircmsg, ErrorLineIsEmpty
 	}
 
 	// tags
-	ircmsg.Tags = make(map[string]TagValue)
 	if line[0] == '@' {
-		splitLine := strings.SplitN(line, " ", 2)
-		if len(splitLine) < 2 {
+		tagEnd := strings.IndexByte(line, ' ')
+		if tagEnd == -1 {
 			return ircmsg, ErrorLineIsEmpty
 		}
-		tags := splitLine[0][1:]
-		line = strings.TrimLeft(splitLine[1], " ")
-
-		if len(line) < 1 {
-			return ircmsg, ErrorLineIsEmpty
+		tags := line[1:tagEnd]
+		if 0 < maxTagDataLength && maxTagDataLength < len(tags) {
+			return ircmsg, ErrorLineTooLong
 		}
-
-		var err error
-		ircmsg.Tags, err = parseTags(tags, maxlenTags, useMaxLen)
+		err = ircmsg.parseTags(tags)
 		if err != nil {
-			return ircmsg, err
+			return
 		}
+		// skip over the tags and the separating space
+		line = line[tagEnd+1:]
 	}
 
 	// truncate if desired
-	if useMaxLen && len(line) > maxlenRest {
-		line = line[:maxlenRest]
+	if 0 < truncateLen && truncateLen < len(line) {
+		line = line[:truncateLen]
 	}
 
 	// prefix
 	if line[0] == ':' {
-		splitLine := strings.SplitN(line, " ", 2)
-		if len(splitLine) < 2 {
+		prefixEnd := strings.IndexByte(line, ' ')
+		if prefixEnd == -1 {
 			return ircmsg, ErrorLineIsEmpty
 		}
-		ircmsg.Prefix = splitLine[0][1:]
-		line = strings.TrimLeft(splitLine[1], " ")
-	}
-
-	if len(line) < 1 {
-		return ircmsg, ErrorLineIsEmpty
+		ircmsg.Prefix = line[1:prefixEnd]
+		// skip over the prefix and the separating space
+		line = line[prefixEnd+1:]
 	}
 
 	// command
-	splitLine := strings.SplitN(line, " ", 2)
-	if len(splitLine[0]) == 0 {
+	commandEnd := strings.IndexByte(line, ' ')
+	paramStart := commandEnd + 1
+	if commandEnd == -1 {
+		commandEnd = len(line)
+		paramStart = len(line)
+	}
+	// normalize command to uppercase:
+	ircmsg.Command = strings.ToUpper(strings.TrimSpace(line[:commandEnd]))
+	if len(ircmsg.Command) == 0 {
 		return ircmsg, ErrorLineIsEmpty
 	}
-	ircmsg.Command = strings.ToUpper(splitLine[0])
-	if len(splitLine) > 1 {
-		line = strings.TrimLeft(splitLine[1], " ")
+	line = line[paramStart:]
 
-		// parameters
-		for {
-			// handle trailing
-			if len(line) > 0 && line[0] == ':' {
-				ircmsg.Params = append(ircmsg.Params, line[1:])
-				break
-			}
-
-			// regular params
-			splitLine := strings.SplitN(line, " ", 2)
-			if len(splitLine[0]) > 0 {
-				ircmsg.Params = append(ircmsg.Params, splitLine[0])
-			}
-
-			if len(splitLine) > 1 {
-				line = strings.TrimLeft(splitLine[1], " ")
-			} else {
-				break
-			}
+	for 0 < len(line) {
+		// handle trailing
+		if line[0] == ':' {
+			ircmsg.Params = append(ircmsg.Params, line[1:])
+			break
 		}
+		paramEnd := strings.IndexByte(line, ' ')
+		if paramEnd == -1 {
+			ircmsg.Params = append(ircmsg.Params, line)
+			break
+		} else if paramEnd == 0 {
+			// only a trailing parameter can be empty
+			return ircmsg, ErrorLineContainsBadChar
+		}
+		ircmsg.Params = append(ircmsg.Params, line[:paramEnd])
+		line = line[paramEnd+1:]
 	}
 
 	return ircmsg, nil
 }
 
-// MakeMessage provides a simple way to create a new IrcMessage.
-func MakeMessage(tags *map[string]TagValue, prefix string, command string, params ...string) IrcMessage {
-	var ircmsg IrcMessage
-
-	ircmsg.Tags = make(map[string]TagValue)
-	if tags != nil {
-		for tag, value := range *tags {
-			ircmsg.Tags[tag] = value
+// helper to parse tags
+func (ircmsg *IrcMessage) parseTags(tags string) (err error) {
+	for 0 < len(tags) {
+		tagEnd := strings.IndexByte(tags, ';')
+		endPos := tagEnd
+		nextPos := tagEnd + 1
+		if tagEnd == -1 {
+			endPos = len(tags)
+			nextPos = len(tags)
 		}
+		tagPair := tags[:endPos]
+		equalsIndex := strings.IndexByte(tagPair, '=')
+		var tagName, tagValue string
+		if equalsIndex == -1 {
+			// tag with no value
+			tagName = tagPair
+		} else {
+			tagName, tagValue = tagPair[:equalsIndex], tagPair[equalsIndex+1:]
+		}
+		ircmsg.SetTag(tagName, UnescapeTagValue(tagValue))
+		// skip over the tag just processed, plus the delimiting ; if any
+		tags = tags[nextPos:]
 	}
+	return nil
+}
 
+// MakeMessage provides a simple way to create a new IrcMessage.
+func MakeMessage(tags map[string]string, prefix string, command string, params ...string) (ircmsg IrcMessage) {
 	ircmsg.Prefix = prefix
 	ircmsg.Command = command
 	ircmsg.Params = params
-
+	ircmsg.UpdateTags(tags)
 	return ircmsg
 }
 
 // Line returns a sendable line created from an IrcMessage.
-func (ircmsg *IrcMessage) Line() (string, error) {
-	bytes, err := ircmsg.line(0, 0, false)
-	return string(bytes), err
+func (ircmsg *IrcMessage) Line() (result string, err error) {
+	bytes, err := ircmsg.line(0, 0, 0, 0)
+	if err == nil {
+		result = string(bytes)
+	}
+	return
 }
 
-// LineBytes returns a sendable line, as a []byte, created from an IrcMessage.
-func (ircmsg *IrcMessage) LineBytes() ([]byte, error) {
-	return ircmsg.line(0, 0, false)
-}
-
-// LineMaxLen returns a sendable line created from an IrcMessage, limited by maxlen.
-func (ircmsg *IrcMessage) LineMaxLen(maxlenTags, maxlenRest int) (string, error) {
-	bytes, err := ircmsg.line(maxlenTags, maxlenRest, true)
-	return string(bytes), err
-}
-
-// LineMaxLen returns a sendable line created from an IrcMessage, limited by maxlen,
-// as a []byte.
-func (ircmsg *IrcMessage) LineMaxLenBytes(maxlenTags, maxlenRest int) ([]byte, error) {
-	return ircmsg.line(maxlenTags, maxlenRest, true)
+// LineBytesStrict returns a sendable line, as a []byte, created from an IrcMessage.
+// fromClient controls whether the server-side or client-side tag length limit
+// is enforced. If truncateLen is nonzero, it is the length at which the
+// non-tag portion of the message is truncated.
+func (ircmsg *IrcMessage) LineBytesStrict(fromClient bool, truncateLen int) ([]byte, error) {
+	var tagLimit, clientOnlyTagDataLimit, serverAddedTagDataLimit int
+	if fromClient {
+		// enforce client max tags:
+		// <client_max>   (4096)  :: '@' <tag_data 4094> ' '
+		tagLimit = MaxlenTagsFromClient
+	} else {
+		// on the server side, enforce separate client-only and server-added tag budgets:
+		// "Servers MUST NOT add tag data exceeding 4094 bytes to messages."
+		// <combined_max> (8191)  :: '@' <tag_data 4094> ';' <tag_data 4094> ' '
+		clientOnlyTagDataLimit = MaxlenClientTagData
+		serverAddedTagDataLimit = MaxlenServerTagData
+	}
+	return ircmsg.line(tagLimit, clientOnlyTagDataLimit, serverAddedTagDataLimit, truncateLen)
 }
 
 // line returns a sendable line created from an IrcMessage.
-func (ircmsg *IrcMessage) line(maxlenTags, maxlenRest int, useMaxLen bool) ([]byte, error) {
+func (ircmsg *IrcMessage) line(tagLimit, clientOnlyTagDataLimit, serverAddedTagDataLimit, truncateLen int) ([]byte, error) {
+	if len(ircmsg.Command) < 1 {
+		return nil, ErrorCommandMissing
+	}
+
 	var buf bytes.Buffer
 
-	if len(ircmsg.Command) < 1 {
-		return nil, errors.New("irc: IRC messages MUST have a command")
-	}
-
-	if len(ircmsg.Tags) > 0 {
-		buf.WriteString("@")
-
+	// write the tags, computing the budgets for client-only tags and regular tags
+	var lenRegularTags, lenClientOnlyTags, lenTags int
+	if 0 < len(ircmsg.tags) || 0 < len(ircmsg.clientOnlyTags) {
+		buf.WriteByte('@')
 		firstTag := true
-		for tag, val := range ircmsg.Tags {
-			if !firstTag {
-				buf.WriteString(";") // delimiter
+		writeTags := func(tags map[string]string) {
+			for tag, val := range tags {
+				if !firstTag {
+					buf.WriteByte(';') // delimiter
+				}
+				buf.WriteString(tag)
+				if val != "" {
+					buf.WriteByte('=')
+					buf.WriteString(EscapeTagValue(val))
+				}
+				firstTag = false
 			}
-			buf.WriteString(tag)
-			if val.HasValue {
-				buf.WriteString("=")
-				buf.WriteString(EscapeTagValue(val.Value))
-			}
-			firstTag = false
 		}
-
-		// truncate if desired
-		if useMaxLen && buf.Len() > maxlenTags {
-			buf.Truncate(maxlenTags)
+		writeTags(ircmsg.tags)
+		lenRegularTags = buf.Len() - 1 // '@' is not counted
+		writeTags(ircmsg.clientOnlyTags)
+		lenClientOnlyTags = (buf.Len() - 1) - lenRegularTags // '@' is not counted
+		if lenRegularTags != 0 {
+			// semicolon between regular and client-only tags is not counted
+			lenClientOnlyTags -= 1
 		}
-
-		buf.WriteString(" ")
+		buf.WriteByte(' ')
 	}
+	lenTags = buf.Len()
 
-	tagsLen := buf.Len()
+	if 0 < tagLimit && tagLimit < buf.Len() {
+		return nil, ErrorLineTooLong
+	}
+	if (0 < clientOnlyTagDataLimit && clientOnlyTagDataLimit < lenClientOnlyTags) || (0 < serverAddedTagDataLimit && serverAddedTagDataLimit < lenRegularTags) {
+		return nil, ErrorLineTooLong
+	}
 
 	if len(ircmsg.Prefix) > 0 {
-		buf.WriteString(":")
+		buf.WriteByte(':')
 		buf.WriteString(ircmsg.Prefix)
-		buf.WriteString(" ")
+		buf.WriteByte(' ')
 	}
 
 	buf.WriteString(ircmsg.Command)
 
-	if len(ircmsg.Params) > 0 {
-		for i, param := range ircmsg.Params {
-			buf.WriteString(" ")
-			if len(param) < 1 || strings.Contains(param, " ") || param[0] == ':' {
-				if i != len(ircmsg.Params)-1 {
-					return nil, errors.New("irc: Cannot have an empty param, a param with spaces, or a param that starts with ':' before the last parameter")
-				}
-				buf.WriteString(":")
+	for i, param := range ircmsg.Params {
+		buf.WriteByte(' ')
+		if len(param) < 1 || strings.IndexByte(param, ' ') != -1 || param[0] == ':' {
+			if i != len(ircmsg.Params)-1 {
+				return nil, ErrorBadParam
 			}
-			buf.WriteString(param)
+			buf.WriteByte(':')
 		}
+		buf.WriteString(param)
 	}
 
 	// truncate if desired
 	// -2 for \r\n
-	restLen := buf.Len() - tagsLen
-	if useMaxLen && restLen > maxlenRest-2 {
-		buf.Truncate(tagsLen + (maxlenRest - 2))
+	restLen := buf.Len() - lenTags
+	if 0 < truncateLen && (truncateLen-2) < restLen {
+		buf.Truncate(lenTags + (truncateLen - 2))
 	}
-
 	buf.WriteString("\r\n")
 
-	return buf.Bytes(), nil
+	result := buf.Bytes()
+	if bytes.IndexByte(result, '\x00') != -1 {
+		return nil, ErrorLineContainsBadChar
+	}
+	return result, nil
 }

--- a/vendor/github.com/goshuirc/irc-go/ircmsg/tags.go
+++ b/vendor/github.com/goshuirc/irc-go/ircmsg/tags.go
@@ -3,28 +3,34 @@
 
 package ircmsg
 
+import "bytes"
 import "strings"
 
 var (
 	// valtoescape replaces real characters with message tag escapes.
 	valtoescape = strings.NewReplacer("\\", "\\\\", ";", "\\:", " ", "\\s", "\r", "\\r", "\n", "\\n")
 
-	// escapetoval contains the IRCv3 Tag Escapes and how they map to characters.
-	escapetoval = map[rune]byte{
-		':':  ';',
-		's':  ' ',
-		'\\': '\\',
-		'r':  '\r',
-		'n':  '\n',
-	}
+	escapedCharLookupTable [256]byte
 )
+
+func init() {
+	// most chars escape to themselves
+	for i := 0; i < 256; i += 1 {
+		escapedCharLookupTable[i] = byte(i)
+	}
+	// these are the exceptions
+	escapedCharLookupTable[':'] = ';'
+	escapedCharLookupTable['s'] = ' '
+	escapedCharLookupTable['r'] = '\r'
+	escapedCharLookupTable['n'] = '\n'
+}
 
 // EscapeTagValue takes a value, and returns an escaped message tag value.
 //
 // This function is automatically used when lines are created from an
 // IrcMessage, so you don't need to call it yourself before creating a line.
-func EscapeTagValue(in string) string {
-	return valtoescape.Replace(in)
+func EscapeTagValue(inString string) string {
+	return valtoescape.Replace(inString)
 }
 
 // UnescapeTagValue takes an escaped message tag value, and returns the raw value.
@@ -32,117 +38,38 @@ func EscapeTagValue(in string) string {
 // This function is automatically used when lines are interpreted by ParseLine,
 // so you don't need to call it yourself after parsing a line.
 func UnescapeTagValue(inString string) string {
-	in := []rune(inString)
-	var out string
-	for 0 < len(in) {
-		if in[0] == '\\' && len(in) > 1 {
-			val, exists := escapetoval[in[1]]
-			if exists == true {
-				out += string(val)
+	// buf.Len() == 0 is the fastpath where we have not needed to unescape any chars
+	var buf bytes.Buffer
+	remainder := inString
+	for {
+		backslashPos := strings.IndexByte(remainder, '\\')
+
+		if backslashPos == -1 {
+			if buf.Len() == 0 {
+				return inString
 			} else {
-				out += string(in[1])
+				buf.WriteString(remainder)
+				break
 			}
-			in = in[2:]
-		} else if in[0] == '\\' {
-			// trailing slash
-			in = in[1:]
-		} else {
-			out += string(in[0])
-			in = in[1:]
-		}
-	}
-
-	return out
-}
-
-// TagValue represents the value of a tag. This is because tags may have
-// no value at all or just an empty value, and this can represent both
-// using the HasValue attribute.
-type TagValue struct {
-	HasValue bool
-	Value    string
-}
-
-// NoTagValue returns an empty TagValue.
-func NoTagValue() TagValue {
-	var tag TagValue
-	tag.HasValue = false
-	return tag
-}
-
-// MakeTagValue returns a TagValue with a defined value.
-func MakeTagValue(value string) TagValue {
-	var tag TagValue
-	tag.HasValue = true
-	tag.Value = value
-	return tag
-}
-
-// MakeTags simplifies tag creation for new messages.
-//
-// For example: MakeTags("intent", "PRIVMSG", "account", "bunny", "noval", nil)
-func MakeTags(values ...interface{}) *map[string]TagValue {
-	var tags map[string]TagValue
-	tags = make(map[string]TagValue)
-
-	for len(values) > 1 {
-		tag := values[0].(string)
-		value := values[1]
-		var val TagValue
-
-		if value == nil {
-			val = NoTagValue()
-		} else {
-			val = MakeTagValue(value.(string))
+		} else if backslashPos == len(remainder)-1 {
+			// trailing backslash, which we strip
+			if buf.Len() == 0 {
+				return inString[:len(inString)-1]
+			} else {
+				buf.WriteString(remainder[:len(remainder)-1])
+				break
+			}
 		}
 
-		tags[tag] = val
-
-		values = values[2:]
-	}
-
-	return &tags
-}
-
-// ParseTags takes a tag string such as "network=freenode;buffer=#chan;joined=1;topic=some\stopic" and outputs a TagValue map.
-func ParseTags(tags string) (map[string]TagValue, error) {
-	return parseTags(tags, 0, false)
-}
-
-// parseTags does the actual tags parsing for the above user-facing function.
-func parseTags(tags string, maxlenTags int, useMaxLen bool) (map[string]TagValue, error) {
-	tagMap := make(map[string]TagValue)
-
-	// confirm no bad strings exist
-	if strings.ContainsAny(tags, " \r\n") {
-		return tagMap, ErrorTagsContainsBadChar
-	}
-
-	// truncate if desired
-	if useMaxLen && len(tags) > maxlenTags {
-		tags = tags[:maxlenTags]
-	}
-
-	for _, fulltag := range strings.Split(tags, ";") {
-		// skip empty tag string values
-		if len(fulltag) < 1 {
-			continue
+		// non-trailing backslash detected; we're now on the slowpath
+		// where we modify the string
+		if buf.Len() == 0 {
+			buf.Grow(len(inString)) // just an optimization
 		}
-
-		var name string
-		var val TagValue
-		if strings.Contains(fulltag, "=") {
-			val.HasValue = true
-			splittag := strings.SplitN(fulltag, "=", 2)
-			name = splittag[0]
-			val.Value = UnescapeTagValue(splittag[1])
-		} else {
-			name = fulltag
-			val.HasValue = false
-		}
-
-		tagMap[name] = val
+		buf.WriteString(remainder[:backslashPos])
+		buf.WriteByte(escapedCharLookupTable[remainder[backslashPos+1]])
+		remainder = remainder[backslashPos+2:]
 	}
 
-	return tagMap, nil
+	return buf.String()
 }


### PR DESCRIPTION
Thanks for these benchmarks, they were quite helpful!

On my system (a low-end Kaby Lake without AVX) we are now losing to you by a factor of at most 2 :-)

````
goos: linux
goarch: amd64
pkg: github.com/jakebailey/irc-benchmarks
BenchmarkEncodeSimple/jakebailey/irc-4         	20000000	       108 ns/op
BenchmarkEncodeSimple/jakebailey/irc_WriteTo-4 	20000000	        92.1 ns/op
BenchmarkEncodeSimple/jakebailey/ircold-4      	20000000	        94.3 ns/op
BenchmarkEncodeSimple/sorcix/irc-4             	20000000	        94.8 ns/op
BenchmarkEncodeSimple/goshuirc/irc-go/ircmsg-4 	20000000	        96.3 ns/op
BenchmarkEncodeTwitch/jakebailey/irc-4         	 2000000	       782 ns/op
BenchmarkEncodeTwitch/jakebailey/irc_WriteTo-4 	 2000000	       695 ns/op
BenchmarkEncodeTwitch/jakebailey/ircold-4      	 1000000	      1110 ns/op
BenchmarkEncodeTwitch/sorcix/irc-4             	 1000000	      1108 ns/op
BenchmarkEncodeTwitch/goshuirc/irc-go/ircmsg-4 	 1000000	      1395 ns/op
BenchmarkEncodeEscaping/jakebailey/irc-4       	 1000000	      1290 ns/op
BenchmarkEncodeEscaping/jakebailey/irc_WriteTo-4         	 1000000	      1145 ns/op
BenchmarkEncodeEscaping/jakebailey/ircold-4              	 1000000	      1242 ns/op
BenchmarkEncodeEscaping/sorcix/irc-4                     	 1000000	      1261 ns/op
BenchmarkEncodeEscaping/goshuirc/irc-go/ircmsg-4         	 1000000	      2042 ns/op
BenchmarkParseSimple/jakebailey/irc-4                    	20000000	       121 ns/op
BenchmarkParseSimple/jakebailey/ircold-4                 	10000000	       193 ns/op
BenchmarkParseSimple/fluffle/goirc/client-4              	 5000000	       331 ns/op
BenchmarkParseSimple/sorcix/irc-4                        	10000000	       188 ns/op
BenchmarkParseSimple/thoj/go-ircevent-4                  	 5000000	       312 ns/op
BenchmarkParseSimple/goshuirc/irc-go/ircmsg-4            	10000000	       148 ns/op
BenchmarkParseSimple/gempir/go-twitch-irc-4              	10000000	       176 ns/op
BenchmarkParseTwitch/jakebailey/irc-4                    	 1000000	      1173 ns/op
BenchmarkParseTwitch/jakebailey/ircold-4                 	  300000	      5251 ns/op
BenchmarkParseTwitch/fluffle/goirc/client-4              	  300000	      5417 ns/op
BenchmarkParseTwitch/sorcix/irc-4                        	  300000	      5224 ns/op
BenchmarkParseTwitch/thoj/go-ircevent-4                  	  300000	      4210 ns/op
BenchmarkParseTwitch/goshuirc/irc-go/ircmsg-4            	 1000000	      2080 ns/op
BenchmarkParseTwitch/gempir/go-twitch-irc-4              	  300000	      4174 ns/op
BenchmarkParseEscaping/jakebailey/irc-4                  	 1000000	      2312 ns/op
BenchmarkParseEscaping/jakebailey/ircold-4               	  200000	      7231 ns/op
BenchmarkParseEscaping/fluffle/goirc/client-4            	  200000	      7363 ns/op
BenchmarkParseEscaping/sorcix/irc-4                      	  200000	      7274 ns/op
BenchmarkParseEscaping/thoj/go-ircevent-4                	  300000	      5895 ns/op
BenchmarkParseEscaping/goshuirc/irc-go/ircmsg-4          	  500000	      2906 ns/op
BenchmarkParseEscaping/gempir/go-twitch-irc-4            	  300000	      4951 ns/op
PASS
ok  	github.com/jakebailey/irc-benchmarks	62.210s
````

Incidentally, how do you get the suite to display memory statistics? `go test -bench -benchmem .` doesn't run the benchmark suite at all for me (I'm on golang 1.12).